### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/commands/audit.py
+++ b/commands/audit.py
@@ -8,6 +8,14 @@ from shared.audit import audit, load_audit_config, finding_is_filtered
 __description__ = "Identify potential issues such as public S3 buckets"
 
 
+def sanitize_resource_details(resource_details):
+    """Sanitize sensitive information in resource details"""
+    if "MinimumPasswordLength" in resource_details:
+        resource_details["MinimumPasswordLength"] = "REDACTED"
+    if "Policy lacks" in resource_details:
+        resource_details["Policy lacks"] = "REDACTED"
+    return resource_details
+
 def audit_command(accounts, config, args):
     """Audit the accounts"""
 
@@ -26,6 +34,7 @@ def audit_command(accounts, config, args):
             finding["finding_type_metadata"] = conf
             print(json.dumps(finding, sort_keys=True))
         elif args.markdown:
+            sanitized_details = sanitize_resource_details(finding.resource_details)
             print(
                 "*Audit Finding: [{}] - {}*\\nAccount: {} ({}) - {}\\nDescription: {}\\nResource: `{}`\\nDetails:```{}```".format(
                     conf["severity"].upper(),
@@ -35,7 +44,7 @@ def audit_command(accounts, config, args):
                     finding.region.name,
                     conf["description"],
                     finding.resource_id,
-                    str(finding.resource_details).replace("\n", "\\n"),
+                    str(sanitized_details).replace("\n", "\\n"),
                 )
             )
         else:


### PR DESCRIPTION
Potential fix for [https://github.com/mani26br/cloudmapper/security/code-scanning/4](https://github.com/mani26br/cloudmapper/security/code-scanning/4)

To fix the problem, we need to ensure that sensitive information is not logged in clear text. One way to achieve this is to sanitize the `resource_details` before logging it. Specifically, we can redact or remove sensitive fields from the `resource_details` before including it in the log message.

We will modify the `audit_command` function in `commands/audit.py` to sanitize the `resource_details` before logging. We will create a helper function `sanitize_resource_details` to handle the sanitization process.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
